### PR TITLE
Add pthread in LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CXX=c++
 COPT	= -O3 -Wall
 
 # Linking flags
-LDFLAGS   =  -lIlmImf -lHalf -lpng
+LDFLAGS   =  -lIlmImf -lHalf -lpng -pthread
 
 ifeq (${OMP},1)
     COPT += -fopenmp


### PR DESCRIPTION
To avoid the following errors at compile time:

```
c++  -L/mnt/data/src/openexr/local/lib -L/usr/local/lib ./io_exr.o  ./libauxiliar.o ./libdenoising.o ./rhf.o  -lIlmImf -lHalf -lpng   -o rhf
libIlmThread-2_2.so.12: undefined reference to `sem_init'
libIlmThread-2_2.so.12: undefined reference to `sem_destroy'
libIlmThread-2_2.so.12: undefined reference to `pthread_create'
libIlmThread-2_2.so.12: undefined reference to `sem_post'
libIlmThread-2_2.so.12: undefined reference to `sem_trywait'
libIlmThread-2_2.so.12: undefined reference to `sem_getvalue'
libIlmThread-2_2.so.12: undefined reference to `sem_wait'
libIlmThread-2_2.so.12: undefined reference to `pthread_join'
collect2: ld returned 1 exit status
make: *** [rhf] Error 1
```
